### PR TITLE
Capture infrastructure exceptions and throw QueueProxyServiceException.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ft</groupId>
     <artifactId>message-queue-consumer</artifactId>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
 
     <packaging>jar</packaging>
     <name>Message queue consumer</name>
@@ -135,6 +135,29 @@
                 </exclusion>
             </exclusions>
         </dependency>
+		<dependency>
+		    <groupId>ch.qos.logback</groupId>
+		    <artifactId>logback-core</artifactId>
+		    <version>1.1.7</version>
+		    <scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>ch.qos.logback</groupId>
+		    <artifactId>logback-classic</artifactId>
+		    <version>1.1.7</version>
+		    <scope>test</scope>
+		</dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+            <version>1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -144,8 +167,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImpl.java
+++ b/src/main/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImpl.java
@@ -4,8 +4,10 @@ import com.ft.message.consumer.config.MessageQueueConsumerConfiguration;
 import com.ft.message.consumer.proxy.model.CreateConsumerInstanceResponse;
 import com.ft.message.consumer.proxy.model.MessageRecord;
 import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.GenericType;
+import com.sun.jersey.api.client.UniformInterfaceException;
 import com.sun.jersey.api.client.WebResource;
 
 import javax.ws.rs.core.UriBuilder;
@@ -43,6 +45,8 @@ public class MessageQueueProxyServiceImpl implements MessageQueueProxyService {
                 throw new QueueProxyServiceException(String.format("Unable to create consumer instance. Proxy returned %d", clientResponse.getStatus()));
             }
             return clientResponse.getEntity(CreateConsumerInstanceResponse.class).getBaseUri();
+        } catch (ClientHandlerException | UniformInterfaceException e) {
+            throw new QueueProxyServiceException("Unable to create consumer instance. Proxy error.", e);
         } finally {
             if (clientResponse != null) {
                 clientResponse.close();
@@ -71,6 +75,8 @@ public class MessageQueueProxyServiceImpl implements MessageQueueProxyService {
             if (clientResponse.getStatus() != 204) {
                 throw new QueueProxyServiceException(String.format("Unable to destroy consumer instance. Proxy returned %d", clientResponse.getStatus()));
             }
+        } catch (ClientHandlerException | UniformInterfaceException e) {
+          throw new QueueProxyServiceException("Unable to destroy consumer instance. Proxy error.", e);
         } finally {
             if (clientResponse != null) {
                 clientResponse.close();
@@ -104,6 +110,8 @@ public class MessageQueueProxyServiceImpl implements MessageQueueProxyService {
 
             return clientResponse.getEntity(new GenericType<List<MessageRecord>>() {
             });
+        } catch (ClientHandlerException | UniformInterfaceException e) {
+          throw new QueueProxyServiceException("Unable to consume messages. Proxy error.", e);
         } finally {
             if (clientResponse != null) {
                 clientResponse.close();
@@ -132,6 +140,8 @@ public class MessageQueueProxyServiceImpl implements MessageQueueProxyService {
             if (clientResponse.getStatus() != 200) {
                 throw new QueueProxyServiceException(String.format("Unable to commit offsets. Proxy returned %d", clientResponse.getStatus()));
             }
+        } catch (ClientHandlerException | UniformInterfaceException e) {
+          throw new QueueProxyServiceException("Unable to commit offsets. Proxy error.", e);
         } finally {
             if (clientResponse != null) {
                 clientResponse.close();

--- a/src/main/java/com/ft/message/consumer/proxy/QueueProxyServiceException.java
+++ b/src/main/java/com/ft/message/consumer/proxy/QueueProxyServiceException.java
@@ -5,4 +5,8 @@ public class QueueProxyServiceException extends RuntimeException {
     public QueueProxyServiceException(String message) {
         super(message);
     }
+    
+    public QueueProxyServiceException(String message, Throwable cause) {
+      super(message, cause);
+  }
 }

--- a/src/test/java/com/ft/message/consumer/LoggingTestHelper.java
+++ b/src/test/java/com/ft/message/consumer/LoggingTestHelper.java
@@ -1,0 +1,91 @@
+package com.ft.message.consumer;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+
+
+public class LoggingTestHelper {
+    private static final String APPENDER = "MockAppender";
+    
+    private static final Map<Class<?>,Level> ORIGINAL_LEVELS = new HashMap<>();
+    
+    public static Logger configureMockAppenderFor(Class<?> clazz) {
+        Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(clazz);
+
+        Appender<ILoggingEvent> appender = mock(Appender.class);
+        when(appender.getName()).thenReturn(APPENDER);
+        logger.addAppender(appender);
+        
+        ORIGINAL_LEVELS.put(clazz, logger.getLevel());
+        logger.setLevel(Level.DEBUG);
+        
+        return logger;
+    }
+
+    public static void resetLoggingFor(Class<?> clazz) {
+        Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(clazz);
+        Appender<ILoggingEvent> appender = logger.getAppender(APPENDER);
+        logger.detachAppender(appender);
+        
+        Level logLevel = ORIGINAL_LEVELS.remove(clazz);
+        if (logLevel != null) {
+            logger.setLevel(logLevel);
+        }
+    }
+    
+    public static void assertLogEvent(Logger logger, String regex, Level... level) {
+      assertLogEvent(logger, regex, true, level);
+    }
+    
+    public static void assertNoLogEvent(Logger logger, String regex, Level... level) {
+      assertLogEvent(logger, regex, false, level);
+    }
+    
+    public static void assertLogEvent(Logger logger, String regex, boolean matching, Level... level) {
+        Appender<ILoggingEvent> appender = logger.getAppender(APPENDER);
+        ArgumentCaptor<LoggingEvent> argument = ArgumentCaptor.forClass(LoggingEvent.class);
+        verify(appender, atLeastOnce()).doAppend(argument.capture());
+        
+        StringBuilder sb = new StringBuilder(regex);
+        if (!regex.startsWith("^")) {
+            sb.insert(0, ".*");
+        }
+        if (!regex.endsWith("$")) {
+            sb.append(".*");
+        }
+        final String pattern = sb.toString();
+        
+        LoggingEvent actual = null;
+        Stream<LoggingEvent> stream = argument.getAllValues().stream()
+                .filter(event -> event.getFormattedMessage().matches(pattern)
+                                  || event.getThrowableProxy().getClassName().matches(pattern));
+        
+        if (matching) {
+          actual = stream.findFirst().get();
+          
+          if ((level != null) && (level.length > 0)) {
+            assertThat(actual.getLevel(), equalTo(level[0]));
+          }
+        }
+        else {
+          assertThat(stream.findFirst().isPresent(), equalTo(false));
+        }
+    }
+}


### PR DESCRIPTION
This allows interrogation of the logs to distinguish between application
exceptions and lower-level network exceptions, such as timeouts for
calls to the Kafka proxy.

Also require Java 8.