### PR TITLE
Feature/passive healthcheck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ft</groupId>
     <artifactId>message-queue-consumer</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
 
     <packaging>jar</packaging>
     <name>Message queue consumer</name>
@@ -62,6 +62,11 @@
                     <artifactId>jetty-server</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.codahale.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.ft</groupId>

--- a/src/main/java/com/ft/message/consumer/health/PassiveMessageQueueProxyConsumerHealthcheck.java
+++ b/src/main/java/com/ft/message/consumer/health/PassiveMessageQueueProxyConsumerHealthcheck.java
@@ -1,0 +1,60 @@
+package com.ft.message.consumer.health;
+
+import java.util.regex.Pattern;
+
+import com.ft.message.consumer.config.HealthcheckConfiguration;
+import com.ft.message.consumer.proxy.MessageQueueProxyService;
+import com.ft.platform.dropwizard.AdvancedHealthCheck;
+import com.ft.platform.dropwizard.AdvancedResult;
+
+public class PassiveMessageQueueProxyConsumerHealthcheck
+    extends AdvancedHealthCheck {
+
+  private static final Pattern OK_STATUS = Pattern.compile(
+      MessageQueueProxyService.MESSAGES_CONSUMED.replace("(", "\\(")
+                                                .replace(")", "\\)")
+                                                .replace("%s", "\\d+")
+                                                .replace(".", "\\."));
+  
+  private final HealthcheckConfiguration healthcheckConfiguration;
+  private final MessageQueueProxyService proxyService;
+  
+  public PassiveMessageQueueProxyConsumerHealthcheck(
+      final HealthcheckConfiguration healthcheckConfiguration,
+      final MessageQueueProxyService proxyService) {
+    
+    super(healthcheckConfiguration.getName());
+    this.healthcheckConfiguration = healthcheckConfiguration;
+    this.proxyService = proxyService;
+  }
+  
+  @Override
+  protected AdvancedResult checkAdvanced() throws Exception {
+    String status = proxyService.getStatus();
+    
+    if (OK_STATUS.matcher(status).matches()) {
+      return AdvancedResult.healthy(status);
+    }
+    return AdvancedResult.error(this, status);
+  }
+
+  @Override
+  protected int severity() {
+    return healthcheckConfiguration.getSeverity();
+  }
+
+  @Override
+  protected String businessImpact() {
+    return healthcheckConfiguration.getBusinessImpact();
+  }
+
+  @Override
+  protected String technicalSummary() {
+    return healthcheckConfiguration.getTechnicalSummary();
+  }
+
+  @Override
+  protected String panicGuideUrl() {
+    return healthcheckConfiguration.getPanicGuideUrl();
+  }
+}

--- a/src/main/java/com/ft/message/consumer/proxy/MessageQueueProxyService.java
+++ b/src/main/java/com/ft/message/consumer/proxy/MessageQueueProxyService.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.util.List;
 
 public interface MessageQueueProxyService {
+    static final String MESSAGES_CONSUMED = "Most recent read consumed %s message(s).";
 
     URI createConsumerInstance();
 
@@ -14,4 +15,6 @@ public interface MessageQueueProxyService {
     List<MessageRecord> consumeMessages(URI consumerInstance);
 
     void commitOffsets(URI consumerInstance);
+    
+    String getStatus();
 }

--- a/src/test/java/com/ft/message/consumer/MessageQueueConsumerInitializerTest.java
+++ b/src/test/java/com/ft/message/consumer/MessageQueueConsumerInitializerTest.java
@@ -1,7 +1,9 @@
 package com.ft.message.consumer;
 
+import com.ft.message.consumer.config.HealthcheckConfiguration;
 import com.ft.message.consumer.config.MessageQueueConsumerConfiguration;
 import com.ft.message.consumer.proxy.MessageQueueProxyService;
+import com.ft.platform.dropwizard.AdvancedHealthCheck;
 import com.sun.jersey.api.client.Client;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,8 +16,12 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -33,10 +39,12 @@ public class MessageQueueConsumerInitializerTest {
     private ExecutorService executorService;
     @Mock
     private MessageQueueConsumer messageQueueConsumer;
+    @Mock
+    private HealthcheckConfiguration healthcheckConfiguration;
 
     @Test
     public void testStop() throws Exception {
-        new MessageQueueConsumerInitializer(messageQueueConsumerConfiguration, messageListener, client, executorService).stop();
+        new MessageQueueConsumerInitializer(messageQueueConsumerConfiguration, messageListener, client, executorService, healthcheckConfiguration).stop();
 
         verify(client).destroy();
         verify(executorService).shutdownNow();
@@ -46,7 +54,7 @@ public class MessageQueueConsumerInitializerTest {
     @Test
     public void testStart() throws Exception {
         when(messageQueueConsumerConfiguration.getStreamCount()).thenReturn(5);
-        new MessageQueueConsumerInitializer(messageQueueConsumerConfiguration, messageListener, client, executorService).start();
+        new MessageQueueConsumerInitializer(messageQueueConsumerConfiguration, messageListener, client, executorService, healthcheckConfiguration).start();
 
         verify(executorService, times(5)).submit(any(MessageQueueConsumerInitializer.InfiniteStreamHandler.class));
     }
@@ -59,5 +67,25 @@ public class MessageQueueConsumerInitializerTest {
         executor.shutdownNow();
 
         assertThat(executor.awaitTermination(1, TimeUnit.SECONDS), is(true));
+    }
+    
+    @Test
+    public void thatHealthcheckIsSupplied() {
+      MessageQueueConsumerInitializer initializer = new MessageQueueConsumerInitializer(
+          messageQueueConsumerConfiguration, messageListener, client,
+          executorService, healthcheckConfiguration);
+      
+      AdvancedHealthCheck actual = initializer.getPassiveConsumerHealthcheck();
+      assertThat(actual, notNullValue());
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void thatHealthcheckRequiresHealthcheckConfiguration() {
+      when(messageQueueConsumerConfiguration.getStreamCount()).thenReturn(1);
+      
+      MessageQueueConsumerInitializer initializer = new MessageQueueConsumerInitializer(
+          messageQueueConsumerConfiguration, messageListener, client);
+      
+      initializer.getPassiveConsumerHealthcheck();
     }
 }

--- a/src/test/java/com/ft/message/consumer/MessageQueueConsumerInitializerTest.java
+++ b/src/test/java/com/ft/message/consumer/MessageQueueConsumerInitializerTest.java
@@ -44,7 +44,7 @@ public class MessageQueueConsumerInitializerTest {
 
     @Test
     public void testStop() throws Exception {
-        new MessageQueueConsumerInitializer(messageQueueConsumerConfiguration, messageListener, client, executorService, healthcheckConfiguration).stop();
+        new MessageQueueConsumerInitializer(messageQueueConsumerConfiguration, messageListener, client, executorService).stop();
 
         verify(client).destroy();
         verify(executorService).shutdownNow();
@@ -54,7 +54,7 @@ public class MessageQueueConsumerInitializerTest {
     @Test
     public void testStart() throws Exception {
         when(messageQueueConsumerConfiguration.getStreamCount()).thenReturn(5);
-        new MessageQueueConsumerInitializer(messageQueueConsumerConfiguration, messageListener, client, executorService, healthcheckConfiguration).start();
+        new MessageQueueConsumerInitializer(messageQueueConsumerConfiguration, messageListener, client, executorService).start();
 
         verify(executorService, times(5)).submit(any(MessageQueueConsumerInitializer.InfiniteStreamHandler.class));
     }
@@ -73,9 +73,9 @@ public class MessageQueueConsumerInitializerTest {
     public void thatHealthcheckIsSupplied() {
       MessageQueueConsumerInitializer initializer = new MessageQueueConsumerInitializer(
           messageQueueConsumerConfiguration, messageListener, client,
-          executorService, healthcheckConfiguration);
+          executorService);
       
-      AdvancedHealthCheck actual = initializer.getPassiveConsumerHealthcheck();
+      AdvancedHealthCheck actual = initializer.buildPassiveConsumerHealthcheck(healthcheckConfiguration, null);
       assertThat(actual, notNullValue());
     }
     
@@ -86,6 +86,6 @@ public class MessageQueueConsumerInitializerTest {
       MessageQueueConsumerInitializer initializer = new MessageQueueConsumerInitializer(
           messageQueueConsumerConfiguration, messageListener, client);
       
-      initializer.getPassiveConsumerHealthcheck();
+      initializer.buildPassiveConsumerHealthcheck(null, null);
     }
 }

--- a/src/test/java/com/ft/message/consumer/health/PassiveMessageQueueProxyConsumerHealthcheckTest.java
+++ b/src/test/java/com/ft/message/consumer/health/PassiveMessageQueueProxyConsumerHealthcheckTest.java
@@ -1,0 +1,75 @@
+package com.ft.message.consumer.health;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.ft.message.consumer.config.HealthcheckConfiguration;
+import com.ft.message.consumer.proxy.MessageQueueProxyService;
+import com.ft.platform.dropwizard.AdvancedResult;
+import com.ft.platform.dropwizard.AdvancedResult.Status;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PassiveMessageQueueProxyConsumerHealthcheckTest {
+  private static final String NAME = "Test Healthcheck";
+  private static final int SEVERITY = 2;
+  private static final String BUSINESS_IMPACT = "Test Business Impact";
+  private static final String TECH_SUMMARY = "Test Tech Summary";
+  private static final String PANIC_GUIDE = "http://panic-guide.example.org/";
+  
+  private PassiveMessageQueueProxyConsumerHealthcheck healthcheck;
+  private HealthcheckConfiguration config = new HealthcheckConfiguration(
+      NAME, SEVERITY, BUSINESS_IMPACT, TECH_SUMMARY, PANIC_GUIDE);
+  
+  @Mock
+  private MessageQueueProxyService service;
+  
+  @Before
+  public void setUp() {
+    healthcheck = new PassiveMessageQueueProxyConsumerHealthcheck(config, service);
+  }
+  
+  @Test
+  public void thatHealthcheckConfigurationIsUsed() {
+    assertThat(healthcheck.severity(), equalTo(SEVERITY));
+    assertThat(healthcheck.businessImpact(), equalTo(BUSINESS_IMPACT));
+    assertThat(healthcheck.technicalSummary(), equalTo(TECH_SUMMARY));
+    assertThat(healthcheck.panicGuideUrl(), equalTo(PANIC_GUIDE));
+  }
+  
+  @Test
+  public void thatHealthcheckIsHealthyWhenMessagesHaveBeenRead() {
+    String message = String.format(MessageQueueProxyService.MESSAGES_CONSUMED, 42);
+    when(service.getStatus()).thenReturn(message);
+    
+    AdvancedResult actual = healthcheck.executeAdvanced();
+    assertThat(actual.status(), equalTo(Status.OK));
+    assertThat(actual.checkOutput(), equalTo(message));
+  }
+  
+  @Test
+  public void thatHealthcheckIsHealthyWhenNoMessagesHaveBeenRead() {
+    String message = String.format(MessageQueueProxyService.MESSAGES_CONSUMED, 0);
+    when(service.getStatus()).thenReturn(message);
+    
+    AdvancedResult actual = healthcheck.executeAdvanced();
+    assertThat(actual.status(), equalTo(Status.OK));
+    assertThat(actual.checkOutput(), equalTo(message));
+  }
+  
+  @Test
+  public void thatHealthcheckIsUnhealthyWhenServiceHasAnErrorCondition() {
+    String message = "Something is wrong";
+    when(service.getStatus()).thenReturn(message);
+    
+    AdvancedResult actual = healthcheck.executeAdvanced();
+    assertThat(actual.status(), equalTo(Status.ERROR));
+    assertThat(actual.checkOutput(), equalTo(message));
+  }
+}

--- a/src/test/java/com/ft/message/consumer/health/PassiveMessageQueueProxyConsumerHealthcheckTest.java
+++ b/src/test/java/com/ft/message/consumer/health/PassiveMessageQueueProxyConsumerHealthcheckTest.java
@@ -32,7 +32,7 @@ public class PassiveMessageQueueProxyConsumerHealthcheckTest {
   
   @Before
   public void setUp() {
-    healthcheck = new PassiveMessageQueueProxyConsumerHealthcheck(config, service);
+    healthcheck = new PassiveMessageQueueProxyConsumerHealthcheck(config, service, null);
   }
   
   @Test


### PR DESCRIPTION
Health monitoring for WPIM and binary ingester is regularly quite flappy. It is believed this is due to the performance of the consumer healthcheck, which connects (as a different consumer group) in both these cases to the NativeCmsPublicationEvents topic. If there are many messages or large messages awaiting delivery to the healthcheck consumer group when the healthcheck is executed, then its performance suffers accordingly.

This feature introduces an alternative, passive health check for the consumer, that merely checks the result of the most recent read by the application, which has negligible performance impact. In the case where the application is polling frequently there is little risk of loss of accuracy in the healthcheck report.