### PR TITLE
Clean shutdown.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ft</groupId>
     <artifactId>message-queue-consumer</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
 
     <packaging>jar</packaging>
     <name>Message queue consumer</name>

--- a/src/main/java/com/ft/message/consumer/MessageQueueConsumer.java
+++ b/src/main/java/com/ft/message/consumer/MessageQueueConsumer.java
@@ -46,7 +46,7 @@ public class MessageQueueConsumer {
                 }
             }
             if(Thread.currentThread().isInterrupted()) {
-                throw new InterruptedException();
+              resetConsumer("Consumer thread has been interrupted.", null);
             }
         } catch (QueueProxyServiceException e) {
           resetConsumer("Error while communicating with queue proxy.", e);
@@ -64,9 +64,11 @@ public class MessageQueueConsumer {
       } catch (Throwable t1) {
         msg += "; Error while destroying consumer instance.";
       } finally {
-        LOGGER.error(String.format("outcome=Exception message=\"%s\"", msg), t);
+        if (t != null) {
+          LOGGER.error(String.format("outcome=Exception message=\"%s\"", msg), t);
           consumerInstance = null;
           backOff();
+        }
       }
     }
     

--- a/src/test/java/com/ft/message/consumer/LoggingTestHelper.java
+++ b/src/test/java/com/ft/message/consumer/LoggingTestHelper.java
@@ -75,7 +75,7 @@ public class LoggingTestHelper {
         LoggingEvent actual = null;
         Stream<LoggingEvent> stream = argument.getAllValues().stream()
                 .filter(event -> event.getFormattedMessage().matches(pattern)
-                                  || event.getThrowableProxy().getClassName().matches(pattern));
+                                  || (event.getThrowableProxy() != null && event.getThrowableProxy().getClassName().matches(pattern)));
         
         if (matching) {
           actual = stream.findFirst().get();


### PR DESCRIPTION
There is no need to throw InterruptedException as the
MessageQueueInitializer checks whether the current thread is interrupted
anyway. Throwing InterruptedException causes spurious error logs that
lead to publish failure alerts in WPIM.