### PR TITLE
Migrate to Confluent Kafka proxy REST API v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,53 @@
 version: 2
 jobs:
   build:
+    working_directory: ~/message-queue-consumer
     docker:
-      - image: coco/dropwizardbase-internal:v1.0.3
+      - image: maven
+      - image: java:openjdk-8
     steps:
       - checkout
       - run:
-          name: Maven
-          command: mvn clean verify
+          name: Maven dependency
+          command: |
+            mkdir /root/.m2/
+            curl -v -o /root/.m2/settings.xml "https://raw.githubusercontent.com/Financial-Times/nexus-settings/master/public-settings.xml"
+            mvn dependency:go-offline
+      - run:
+          name: Maven integration Tests
+          command: |
+            curl -v -o /root/.m2/settings.xml "https://raw.githubusercontent.com/Financial-Times/nexus-settings/master/public-settings.xml"
+            mvn clean verify
+            rm -rf /root/.m2/*
+  publish-nexus:
+    working_directory: ~/message-queue-consumer
+    docker:
+      - image: coco/dropwizardbase-internal:v1.0.3
+    steps:
+      - checkout:
+            path: ~/message-queue-consumer
+      - run:
+          name: Publish Tag to Nexus repository
+          command: |
+            mvn versions:set -DnewVersion=${CIRCLE_TAG}
+            mvn versions:commit
+            mvn deploy
+
+workflows:
+  version: 2
+  test-and-build:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - publish-nexus:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+(-[a-z0-9-]+)?$/
+     
+          

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ backoffPeriod - period in milliseconds for which the app will sleep before tryin
 autoCommit - boolean flag which configures autoCommit when consuming messages. If true offsets are committed if the consume request to the proxy returns 200.
            - if false offsets are manually committed after the batch of messages are processed
            - because of the proxy limitations the recommendations are to use autocommit true for topics with small messages
-offsetReset - possible values are "smallest" and "largest"
-            - smallest means start processing all available messages from a kafka topic
-            - largest means start processing messages which are produced after the consumer started
-            - because of the proxy limitations the recommendations are to use "largest" unless you have a very good reasons not to
-            - using smallest will impact the memory usage of the proxy
+offsetReset - possible values are "none", "earliest" and "latest"
+            - earliest: start processing all messages from the beginning of a Kafka topic
+            - latest: start processing messages which are produced after the consumer started
+            - none: throw exception to the consumer if no previous offset is found for the consumer's group
+            - because of the proxy limitations the recommendations are to use "latest" unless you have a very good reasons not to
+            - using "earliest" will impact the memory usage of the proxy
 streamCount - number of threads to use for processing messages
             - each thread will create a new proxy consumer instance which will be assigned to different kafka partition(s)
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # message-queue-consumer
 
-Library which does polling to consume messages from a message queue via an http proxy. Supports group and topic semantics.
+A library that is an intermediary to Confluent Kafka REST Proxy. It implements v2 of the API: <https://docs.confluent.io/current/kafka-rest/api.html#api-v2>.
 
-## Configuration
+It supports the following settings:
+
 
 ```
 topicName - name of the topic from which to consume messages

--- a/src/main/java/com/ft/message/consumer/MessageQueueConsumer.java
+++ b/src/main/java/com/ft/message/consumer/MessageQueueConsumer.java
@@ -35,6 +35,7 @@ public class MessageQueueConsumer {
         try {
             if (consumerInstance == null) {
                 consumerInstance = messageQueueProxyService.createConsumerInstance();
+                messageQueueProxyService.subscribeConsumerInstanceToTopic(consumerInstance);
             }
             List<MessageRecord> messageRecords = messageQueueProxyService.consumeMessages(consumerInstance);
             if (messageRecords == null || messageRecords.isEmpty()) {
@@ -59,6 +60,7 @@ public class MessageQueueConsumer {
       String msg = reason;
       try {
           if (consumerInstance != null) {
+              messageQueueProxyService.destroyConsumerInstanceSubscription(consumerInstance);
               messageQueueProxyService.destroyConsumerInstance(consumerInstance);
           }
       } catch (Throwable t1) {

--- a/src/main/java/com/ft/message/consumer/config/MessageQueueConsumerConfiguration.java
+++ b/src/main/java/com/ft/message/consumer/config/MessageQueueConsumerConfiguration.java
@@ -1,6 +1,7 @@
 package com.ft.message.consumer.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Strings;
 
 public class MessageQueueConsumerConfiguration {
 
@@ -28,7 +29,8 @@ public class MessageQueueConsumerConfiguration {
         this.autoCommit = autoCommit;
         this.backoffPeriod = backoffPeriod == 0? 8000 : backoffPeriod;
         this.streamCount = streamCount == 0? 1 : streamCount;
-        this.offsetReset = offsetReset == null? "largest" : offsetReset;
+        // Any value of offsetReset other than "latest", "earliest" or "none" causes a Kafka consumer exception
+        this.offsetReset = Strings.isNullOrEmpty(offsetReset) ? "latest" : offsetReset;
     }
 
     public String getTopicName() {

--- a/src/main/java/com/ft/message/consumer/health/CanConnectToMessageQueueProxyHealthcheck.java
+++ b/src/main/java/com/ft/message/consumer/health/CanConnectToMessageQueueProxyHealthcheck.java
@@ -5,6 +5,7 @@ import com.ft.message.consumer.config.MessageQueueConsumerConfiguration;
 import com.ft.message.consumer.proxy.model.CreateConsumerInstanceResponse;
 import com.ft.platform.dropwizard.AdvancedHealthCheck;
 import com.ft.platform.dropwizard.AdvancedResult;
+import com.google.common.base.Strings;
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
@@ -20,6 +21,7 @@ public class CanConnectToMessageQueueProxyHealthcheck extends AdvancedHealthChec
     private static final String groupName = "healthcheck";
     private static final int HTTP_RESPONSE_OK = 200;
     private static final int HTTP_RESPONSE_NO_CONTENT = 204;
+    private static final String KAFKA_MESSAGE_CONTENT_TYPE = "application/vnd.kafka.v2+json";
 
     private MessageQueueConsumerConfiguration configuration;
     private HealthcheckConfiguration healthcheckConfiguration;
@@ -75,13 +77,13 @@ public class CanConnectToMessageQueueProxyHealthcheck extends AdvancedHealthChec
 
     protected ClientResponse deleteConsumerInstance(URI consumerInstance) {
         UriBuilder uriBuilder = UriBuilder.fromUri(consumerInstance);
-        if (queueIsNotEmpty()) {
+        if (!Strings.isNullOrEmpty(configuration.getQueue())) {
             addProxyPortAndHostInUri(uriBuilder);
         }
         URI uri = uriBuilder.build();
 
         WebResource.Builder builder = proxyClient.resource(uri).getRequestBuilder();
-        if (queueIsNotEmpty()) {
+        if (!Strings.isNullOrEmpty(configuration.getQueue())) {
             builder.header("Host", configuration.getQueue());
         }
         return builder.delete(ClientResponse.class);
@@ -89,8 +91,8 @@ public class CanConnectToMessageQueueProxyHealthcheck extends AdvancedHealthChec
 
     protected ClientResponse getClientResponseForMessageConsumer(URI readMessageFromUri) {
         WebResource.Builder builder = proxyClient.resource(readMessageFromUri).getRequestBuilder();
-        builder.header("Accept", "application/json");
-        if (queueIsNotEmpty()) {
+        builder.header("Accept", KAFKA_MESSAGE_CONTENT_TYPE);
+        if (!Strings.isNullOrEmpty(configuration.getQueue())) {
             builder.header("Host", configuration.getQueue());
         }
         return builder.get(ClientResponse.class);
@@ -98,8 +100,9 @@ public class CanConnectToMessageQueueProxyHealthcheck extends AdvancedHealthChec
 
     protected ClientResponse getClientResponseForProxyConnection(URI uri) {
         WebResource.Builder builder = proxyClient.resource(uri).getRequestBuilder();
-        builder.header("Content-Type", "application/json");
-        if (queueIsNotEmpty()) {
+        builder.header("Content-Type", KAFKA_MESSAGE_CONTENT_TYPE);
+
+        if (!Strings.isNullOrEmpty(configuration.getQueue())) {
             builder.header("Host", configuration.getQueue());
         }
         return builder.post(ClientResponse.class);
@@ -107,7 +110,7 @@ public class CanConnectToMessageQueueProxyHealthcheck extends AdvancedHealthChec
 
     private URI buildMessageReaderUri(URI consumerUri) {
         UriBuilder uriBuilder = UriBuilder.fromUri(consumerUri).path("topics").path(configuration.getTopicName());
-        if (queueIsNotEmpty()) {
+        if (!Strings.isNullOrEmpty(configuration.getQueue())) {
             addProxyPortAndHostInUri(uriBuilder);
         }
         return uriBuilder.build();
@@ -124,10 +127,6 @@ public class CanConnectToMessageQueueProxyHealthcheck extends AdvancedHealthChec
     private void addProxyPortAndHostInUri(UriBuilder uriBuilder) {
         URI proxyUri = UriBuilder.fromUri(configuration.getQueueProxyHost()).build();
         uriBuilder.host(proxyUri.getHost()).port(proxyUri.getPort());
-    }
-
-    private boolean queueIsNotEmpty() {
-        return configuration.getQueue() != null && !configuration.getQueue().isEmpty();
     }
 
     private AdvancedResult reportUnhealthy(String message) {

--- a/src/main/java/com/ft/message/consumer/health/CanConnectToMessageQueueProxyHealthcheck.java
+++ b/src/main/java/com/ft/message/consumer/health/CanConnectToMessageQueueProxyHealthcheck.java
@@ -2,7 +2,7 @@ package com.ft.message.consumer.health;
 
 import com.ft.message.consumer.config.HealthcheckConfiguration;
 import com.ft.message.consumer.config.MessageQueueConsumerConfiguration;
-import com.ft.message.consumer.proxy.model.CreateConsumerInstanceResponse;
+import com.ft.message.consumer.proxy.model.ConsumerInstanceResponse;
 import com.ft.platform.dropwizard.AdvancedHealthCheck;
 import com.ft.platform.dropwizard.AdvancedResult;
 import com.google.common.base.Strings;
@@ -47,7 +47,7 @@ public class CanConnectToMessageQueueProxyHealthcheck extends AdvancedHealthChec
                 return reportUnhealthy(String.format("Unable to connect to queue proxy. %d", clientResponseToCreateConsumer.getStatus()));
             }
 
-            URI consumerInstance = clientResponseToCreateConsumer.getEntity(CreateConsumerInstanceResponse.class).getBaseUri();
+            URI consumerInstance = clientResponseToCreateConsumer.getEntity(ConsumerInstanceResponse.class).getBaseUri();
             URI messageReaderUri = buildMessageReaderUri(consumerInstance);
             clientResponseToCheckTopic = getClientResponseForMessageConsumer(messageReaderUri);
             if (clientResponseToCheckTopic.getStatus() != HTTP_RESPONSE_OK) {

--- a/src/main/java/com/ft/message/consumer/proxy/MessageQueueProxyService.java
+++ b/src/main/java/com/ft/message/consumer/proxy/MessageQueueProxyService.java
@@ -12,6 +12,10 @@ public interface MessageQueueProxyService {
 
     void destroyConsumerInstance(URI consumerInstance);
 
+    void subscribeConsumerInstanceToTopic(URI consumerInstance);
+
+    void destroyConsumerInstanceSubscription(URI consumerInstance);
+
     List<MessageRecord> consumeMessages(URI consumerInstance);
 
     void commitOffsets(URI consumerInstance);

--- a/src/main/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImpl.java
+++ b/src/main/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImpl.java
@@ -112,10 +112,10 @@ public class MessageQueueProxyServiceImpl implements MessageQueueProxyService {
         try {
             UriBuilder uriBuilder = UriBuilder.fromUri(consumerInstance)
                     .path("subscription");
-            URI uri = uriBuilder.build();
             if (!Strings.isNullOrEmpty(configuration.getQueue())) {
                 addProxyPortAndHostInUri(uriBuilder);
             }
+            URI uri = uriBuilder.build();
 
             WebResource.Builder builder = proxyClient.resource(uri).getRequestBuilder();
             builder.header("Content-Type", KAFKA_MESSAGE_CONTENT_TYPE);

--- a/src/main/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImpl.java
+++ b/src/main/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImpl.java
@@ -21,7 +21,7 @@ public class MessageQueueProxyServiceImpl implements MessageQueueProxyService {
     private static final String CONSUME = "consume messages";
     private static final String COMMIT = "commit offsets";
     private static final String DESTROY = "destroy consumer instance";
-    private static final String KAFKA_PROXY_V2 = "application/vnd.kafka.v2+json";
+    private static final String KAFKA_MESSAGE_CONTENT_TYPE = "application/vnd.kafka.v2+json";
 
     private static final int SC_NO_CONTENT = ClientResponse.Status.NO_CONTENT.getStatusCode();
     private static final int SC_OK = ClientResponse.Status.OK.getStatusCode();
@@ -59,7 +59,7 @@ public class MessageQueueProxyServiceImpl implements MessageQueueProxyService {
                     .build();
 
             WebResource.Builder builder = proxyClient.resource(uri).getRequestBuilder();
-            builder.header("Content-Type", KAFKA_PROXY_V2);
+            builder.header("Content-Type", KAFKA_MESSAGE_CONTENT_TYPE);
             if (queueIsNotEmpty()) {
                 builder.header("Host", configuration.getQueue());
             }
@@ -87,7 +87,7 @@ public class MessageQueueProxyServiceImpl implements MessageQueueProxyService {
             URI uri = uriBuilder.build();
 
             WebResource.Builder builder = proxyClient.resource(uri).getRequestBuilder();
-            builder.header("Accept", KAFKA_PROXY_V2);
+            builder.header("Accept", KAFKA_MESSAGE_CONTENT_TYPE);
             if (queueIsNotEmpty()) {
                 builder.header("Host", configuration.getQueue());
             }
@@ -113,7 +113,7 @@ public class MessageQueueProxyServiceImpl implements MessageQueueProxyService {
                     .build();
 
             WebResource.Builder builder = proxyClient.resource(uri).getRequestBuilder();
-            builder.header("Content-Type", KAFKA_PROXY_V2);
+            builder.header("Content-Type", KAFKA_MESSAGE_CONTENT_TYPE);
             if (queueIsNotEmpty()) {
                 builder.header("Host", configuration.getQueue());
             }
@@ -142,7 +142,7 @@ public class MessageQueueProxyServiceImpl implements MessageQueueProxyService {
             URI uri = uriBuilder.build();
 
             WebResource.Builder builder = proxyClient.resource(uri).getRequestBuilder();
-            builder.header("Accept", KAFKA_PROXY_V2);
+            builder.header("Accept", KAFKA_MESSAGE_CONTENT_TYPE);
             if (queueIsNotEmpty()) {
                 builder.header("Host", configuration.getQueue());
             }
@@ -173,7 +173,7 @@ public class MessageQueueProxyServiceImpl implements MessageQueueProxyService {
             URI uri = uriBuilder.build();
 
             WebResource.Builder builder = proxyClient.resource(uri).getRequestBuilder();
-            builder.header("Accept", KAFKA_PROXY_V2);
+            builder.header("Accept", KAFKA_MESSAGE_CONTENT_TYPE);
             if (queueIsNotEmpty()) {
                 builder.header("Host", configuration.getQueue());
             }

--- a/src/main/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImpl.java
+++ b/src/main/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImpl.java
@@ -1,7 +1,7 @@
 package com.ft.message.consumer.proxy;
 
 import com.ft.message.consumer.config.MessageQueueConsumerConfiguration;
-import com.ft.message.consumer.proxy.model.CreateConsumerInstanceResponse;
+import com.ft.message.consumer.proxy.model.ConsumerInstanceResponse;
 import com.ft.message.consumer.proxy.model.MessageRecord;
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientHandlerException;
@@ -65,7 +65,7 @@ public class MessageQueueProxyServiceImpl implements MessageQueueProxyService {
             }
             clientResponse = builder.post(ClientResponse.class, String.format("{\"auto.offset.reset\": \"%s\", \"auto.commit.enable\": \"%b\"}", configuration.getOffsetReset(), configuration.isAutoCommit()));
             checkStatus(clientResponse, SC_OK, CREATE);
-            return clientResponse.getEntity(CreateConsumerInstanceResponse.class).getBaseUri();
+            return clientResponse.getEntity(ConsumerInstanceResponse.class).getBaseUri();
         } catch (ClientHandlerException | UniformInterfaceException e) {
           throw proxyException(e, CREATE);
         } finally {

--- a/src/main/java/com/ft/message/consumer/proxy/model/ConsumerInstanceResponse.java
+++ b/src/main/java/com/ft/message/consumer/proxy/model/ConsumerInstanceResponse.java
@@ -6,11 +6,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URI;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class CreateConsumerInstanceResponse {
+public class ConsumerInstanceResponse {
 
     private URI baseUri;
 
-    public CreateConsumerInstanceResponse(@JsonProperty("base_uri") URI baseUri) {
+    public ConsumerInstanceResponse(@JsonProperty("base_uri") URI baseUri) {
         this.baseUri = baseUri;
     }
 

--- a/src/test/java/com/ft/message/consumer/config/MessageQueueConsumerConfigurationTest.java
+++ b/src/test/java/com/ft/message/consumer/config/MessageQueueConsumerConfigurationTest.java
@@ -10,43 +10,43 @@ public class MessageQueueConsumerConfigurationTest {
 
     @Test
     public void testShouldUseConfiguredBackoffPeriod() throws Exception {
-        MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 2000, 1, "smallest", false);
+        MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 2000, 1, "earliest", false);
         assertThat(messageQueueConsumerConfiguration.getBackoffPeriod(), is(equalTo(2000)));
     }
 
     @Test
     public void testDefaultTo8sIfBackoffPeriodNotConfigured() throws Exception {
-        MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 0, 1, "smallest", false);
+        MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 0, 1, "earliest", false);
         assertThat(messageQueueConsumerConfiguration.getBackoffPeriod(), is(equalTo(8000)));
     }
 
     @Test
     public void testShouldUseConfiguredStreamCount() throws Exception {
-        MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 2000, 4, "smallest", false);
+        MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 2000, 4, "earliest", false);
         assertThat(messageQueueConsumerConfiguration.getStreamCount(), is(equalTo(4)));
     }
 
     @Test
     public void testDefaultTo1IfStreamCountNotConfigured() throws Exception {
-        MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 0, 0, "smallest", false);
+        MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 0, 0, "earliest", false);
         assertThat(messageQueueConsumerConfiguration.getStreamCount(), is(equalTo(1)));
     }
 
     @Test
     public void testShouldUseConfiguredOffsetReset() throws Exception {
-        MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 2000, 1, "smallest", false);
-        assertThat(messageQueueConsumerConfiguration.getOffsetReset(), is(equalTo("smallest")));
+        MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 2000, 1, "earliest", false);
+        assertThat(messageQueueConsumerConfiguration.getOffsetReset(), is(equalTo("earliest")));
     }
 
     @Test
-    public void testDefaultToLargestIfOffsetResetNotConfigured() throws Exception {
+    public void testDefaultToLatestIfOffsetResetNotConfigured() throws Exception {
         MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 0, 1, null, false);
-        assertThat(messageQueueConsumerConfiguration.getOffsetReset(), is(equalTo("largest")));
+        assertThat(messageQueueConsumerConfiguration.getOffsetReset(), is(equalTo("latest")));
     }
 
     @Test
     public void testShouldUseConfiguredAutoCommit() throws Exception {
-        MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 2000, 1, "smallest", true);
+        MessageQueueConsumerConfiguration messageQueueConsumerConfiguration = new MessageQueueConsumerConfiguration("CmsPublicationEvent", "group1", "http://localhost:8082", "kafka", 2000, 1, "earliest", true);
         assertThat(messageQueueConsumerConfiguration.isAutoCommit(), is(equalTo(true)));
     }
 }

--- a/src/test/java/com/ft/message/consumer/health/CanConnectToMessageQueueProxyHealthcheckTest.java
+++ b/src/test/java/com/ft/message/consumer/health/CanConnectToMessageQueueProxyHealthcheckTest.java
@@ -2,7 +2,7 @@ package com.ft.message.consumer.health;
 
 import com.ft.message.consumer.config.HealthcheckConfiguration;
 import com.ft.message.consumer.config.MessageQueueConsumerConfiguration;
-import com.ft.message.consumer.proxy.model.CreateConsumerInstanceResponse;
+import com.ft.message.consumer.proxy.model.ConsumerInstanceResponse;
 import com.ft.platform.dropwizard.AdvancedResult;
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
@@ -125,8 +125,8 @@ public class CanConnectToMessageQueueProxyHealthcheckTest {
         doNothing().when(mockClientResponse).close();
 
         if (statusCode == HTTP_RESPONSE_OK) {
-            CreateConsumerInstanceResponse response = mock(CreateConsumerInstanceResponse.class);
-            when(mockClientResponse.getEntity(CreateConsumerInstanceResponse.class)).thenReturn(response);
+            ConsumerInstanceResponse response = mock(ConsumerInstanceResponse.class);
+            when(mockClientResponse.getEntity(ConsumerInstanceResponse.class)).thenReturn(response);
             doReturn(new URI("uri")).when(response).getBaseUri();
         }
 

--- a/src/test/java/com/ft/message/consumer/health/CanConnectToMessageQueueProxyHealthcheckTest.java
+++ b/src/test/java/com/ft/message/consumer/health/CanConnectToMessageQueueProxyHealthcheckTest.java
@@ -47,7 +47,7 @@ public class CanConnectToMessageQueueProxyHealthcheckTest {
     @Before
     public void setUp() {
         healtcheckConfiguration = new HealthcheckConfiguration("kafka-proxy", 2, "business impact text", "tech summary", "panic guide url");
-        MessageQueueConsumerConfiguration consumerConfiguration = new MessageQueueConsumerConfiguration(topicName, groupName, proxyHost, "kafka", 8000, 1, "smallest", false);
+        MessageQueueConsumerConfiguration consumerConfiguration = new MessageQueueConsumerConfiguration(topicName, groupName, proxyHost, "kafka", 8000, 1, "earliest", false);
         healthcheck = new CanConnectToMessageQueueProxyHealthcheck(mockClient, consumerConfiguration, healtcheckConfiguration);
     }
 

--- a/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplTest.java
+++ b/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplTest.java
@@ -76,7 +76,7 @@ public class MessageQueueProxyServiceImplTest {
 
         assertThat(actualConsumerInstanceUri, is(equalTo(expectedUri)));
 
-        verify(mockedBuilder).header(eq("Content-Type"), eq("application/json"));
+        verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
         verify(mockedBuilder).header(eq("Host"), eq("kafka"));
         verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"false\"}");
         verify(mockedResponse, times(1)).close();
@@ -111,7 +111,7 @@ public class MessageQueueProxyServiceImplTest {
 
         assertThat(actualConsumerInstanceUri, is(equalTo(expectedUri)));
 
-        verify(mockedBuilder).header(eq("Content-Type"), eq("application/json"));
+        verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
         verify(mockedBuilder).header(eq("Host"), eq("kafka"));
         verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"true\"}");
         verify(mockedResponse, times(1)).close();
@@ -136,7 +136,7 @@ public class MessageQueueProxyServiceImplTest {
         try {
           messageQueueProxyService.createConsumerInstance();
         } finally {
-          verify(mockedBuilder).header(eq("Content-Type"), eq("application/json"));
+          verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
           verify(mockedBuilder).header(eq("Host"), eq("kafka"));
           verify(mockedResponse, times(1)).close();
           
@@ -159,7 +159,7 @@ public class MessageQueueProxyServiceImplTest {
         try {
           messageQueueProxyService.createConsumerInstance();
         } finally {
-          verify(mockedBuilder).header(eq("Content-Type"), eq("application/json"));
+          verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
           verify(mockedBuilder).header(eq("Host"), eq("kafka"));
           
           assertThat(messageQueueProxyService.getStatus(), equalTo(errorMessage));
@@ -264,7 +264,7 @@ public class MessageQueueProxyServiceImplTest {
         final URI consumerUri = UriBuilder.fromUri("http://localhost:8082/consumers/binaryIngester/instances/rest-consumer-1-1").build();
 
         final WebResource mockedWebResource = mock(WebResource.class);
-        when(client.resource(UriBuilder.fromUri(consumerUri).path("topics").path("CmsPublicationEvent").build())).thenReturn(mockedWebResource);
+        when(client.resource(UriBuilder.fromUri(consumerUri).path("records").build())).thenReturn(mockedWebResource);
         final WebResource.Builder mockedBuilder = mock(WebResource.Builder.class);
         when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
         final ClientResponse mockedResponse = mock(ClientResponse.class);
@@ -276,7 +276,7 @@ public class MessageQueueProxyServiceImplTest {
 
         assertThat(actualMessageRecords.get(0).getValue(), is(equalTo("myrecord".getBytes())));
         verify(mockedBuilder).header(eq("Host"), eq("kafka"));
-        verify(mockedBuilder).header(eq("Accept"), eq("application/json"));
+        verify(mockedBuilder).header(eq("Accept"), eq("application/vnd.kafka.v2+json"));
         verify(mockedResponse, times(1)).close();
         
         assertThat(messageQueueProxyService.getStatus(), equalTo(ONE_MSG));
@@ -288,7 +288,7 @@ public class MessageQueueProxyServiceImplTest {
         final URI expectedOverridenUri = UriBuilder.fromUri("http://localhost:8082/consumers/binaryIngester/instances/rest-consumer-1-1").build();
 
         final WebResource mockedWebResource = mock(WebResource.class);
-        when(client.resource(UriBuilder.fromUri(expectedOverridenUri).path("topics").path("CmsPublicationEvent").build())).thenReturn(mockedWebResource);
+        when(client.resource(UriBuilder.fromUri(expectedOverridenUri).path("records").build())).thenReturn(mockedWebResource);
         final WebResource.Builder mockedBuilder = mock(WebResource.Builder.class);
         when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
         final ClientResponse mockedResponse = mock(ClientResponse.class);
@@ -299,9 +299,9 @@ public class MessageQueueProxyServiceImplTest {
         List<MessageRecord> actualMessageRecords = messageQueueProxyService.consumeMessages(consumerUri);
 
         assertThat(actualMessageRecords.get(0).getValue(), is(equalTo("myrecord".getBytes())));
-        verify(client).resource(UriBuilder.fromUri(expectedOverridenUri).path("topics").path("CmsPublicationEvent").build());
+        verify(client).resource(UriBuilder.fromUri(expectedOverridenUri).path("records").build());
         verify(mockedBuilder).header(eq("Host"), eq("kafka"));
-        verify(mockedBuilder).header(eq("Accept"), eq("application/json"));
+        verify(mockedBuilder).header(eq("Accept"), eq("application/vnd.kafka.v2+json"));
         verify(mockedResponse, times(1)).close();
         
         assertThat(messageQueueProxyService.getStatus(), equalTo(ONE_MSG));
@@ -315,7 +315,7 @@ public class MessageQueueProxyServiceImplTest {
         expectedException.expectMessage(errorMessage);
 
         final WebResource mockedWebResource = mock(WebResource.class);
-        when(client.resource(UriBuilder.fromUri(consumerUri).path("topics").path("CmsPublicationEvent").build())).thenReturn(mockedWebResource);
+        when(client.resource(UriBuilder.fromUri(consumerUri).path("records").build())).thenReturn(mockedWebResource);
         final WebResource.Builder mockedBuilder = mock(WebResource.Builder.class);
         when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
         final ClientResponse mockedResponse = mock(ClientResponse.class);
@@ -326,7 +326,7 @@ public class MessageQueueProxyServiceImplTest {
           messageQueueProxyService.consumeMessages(consumerUri);
         } finally {
           verify(mockedBuilder).header(eq("Host"), eq("kafka"));
-          verify(mockedBuilder).header(eq("Accept"), eq("application/json"));
+          verify(mockedBuilder).header(eq("Accept"), eq("application/vnd.kafka.v2+json"));
           verify(mockedResponse, times(1)).close();
           
           assertThat(messageQueueProxyService.getStatus(), equalTo(errorMessage));
@@ -341,7 +341,7 @@ public class MessageQueueProxyServiceImplTest {
         expectedException.expectMessage(errorMessage);
 
         final WebResource mockedWebResource = mock(WebResource.class);
-        when(client.resource(UriBuilder.fromUri(consumerUri).path("topics").path("CmsPublicationEvent").build())).thenReturn(mockedWebResource);
+        when(client.resource(UriBuilder.fromUri(consumerUri).path("records").build())).thenReturn(mockedWebResource);
         final WebResource.Builder mockedBuilder = mock(WebResource.Builder.class);
         when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
         when(mockedBuilder.get(ClientResponse.class)).thenThrow(new ClientHandlerException("test timeout"));
@@ -350,7 +350,7 @@ public class MessageQueueProxyServiceImplTest {
           messageQueueProxyService.consumeMessages(consumerUri);
         } finally {
           verify(mockedBuilder).header(eq("Host"), eq("kafka"));
-          verify(mockedBuilder).header(eq("Accept"), eq("application/json"));
+          verify(mockedBuilder).header(eq("Accept"), eq("application/vnd.kafka.v2+json"));
           
           assertThat(messageQueueProxyService.getStatus(), equalTo(errorMessage));
         }

--- a/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplTest.java
+++ b/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplTest.java
@@ -53,7 +53,7 @@ public class MessageQueueProxyServiceImplTest {
                         "binaryIngester",
                         "http://localhost:8082",
                         "kafka",
-                        8000, 1, "smallest", false),
+                        8000, 1, "earliest", false),
                 client);
     }
 
@@ -68,7 +68,7 @@ public class MessageQueueProxyServiceImplTest {
         when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
 
         final ClientResponse mockedResponse = mock(ClientResponse.class);
-        when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"false\"}")).thenReturn(mockedResponse);
+        when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"false\"}")).thenReturn(mockedResponse);
         when(mockedResponse.getStatus()).thenReturn(200);
         when(mockedResponse.getEntity(CreateConsumerInstanceResponse.class)).thenReturn(new CreateConsumerInstanceResponse(expectedUri));
 
@@ -78,7 +78,7 @@ public class MessageQueueProxyServiceImplTest {
 
         verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
         verify(mockedBuilder).header(eq("Host"), eq("kafka"));
-        verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"false\"}");
+        verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"false\"}");
         verify(mockedResponse, times(1)).close();
         
         assertThat(messageQueueProxyService.getStatus(), equalTo(NO_MSG));
@@ -92,7 +92,7 @@ public class MessageQueueProxyServiceImplTest {
                         "binaryIngester",
                         "http://localhost:8082",
                         "kafka",
-                        8000, 1, "smallest", true),
+                        8000, 1, "earliest", true),
                 client);
 
         final URI expectedUri = UriBuilder.fromUri("http://localhost:8082/consumers/binaryIngester/instances/rest-consumer-1-1").build();
@@ -103,7 +103,7 @@ public class MessageQueueProxyServiceImplTest {
         when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
 
         final ClientResponse mockedResponse = mock(ClientResponse.class);
-        when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"true\"}")).thenReturn(mockedResponse);
+        when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"true\"}")).thenReturn(mockedResponse);
         when(mockedResponse.getStatus()).thenReturn(200);
         when(mockedResponse.getEntity(CreateConsumerInstanceResponse.class)).thenReturn(new CreateConsumerInstanceResponse(expectedUri));
 
@@ -113,7 +113,7 @@ public class MessageQueueProxyServiceImplTest {
 
         verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
         verify(mockedBuilder).header(eq("Host"), eq("kafka"));
-        verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"true\"}");
+        verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"true\"}");
         verify(mockedResponse, times(1)).close();
         
         assertThat(messageQueueProxyService.getStatus(), equalTo(NO_MSG));
@@ -130,7 +130,7 @@ public class MessageQueueProxyServiceImplTest {
         final WebResource.Builder mockedBuilder = mock(WebResource.Builder.class);
         when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
         final ClientResponse mockedResponse = mock(ClientResponse.class);
-        when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"false\"}")).thenReturn(mockedResponse);
+        when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"false\"}")).thenReturn(mockedResponse);
         when(mockedResponse.getStatus()).thenReturn(500);
         
         try {

--- a/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplTest.java
+++ b/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.when;
 public class MessageQueueProxyServiceImplTest {
   private static final String NO_MSG = String.format(MessageQueueProxyService.MESSAGES_CONSUMED, 0);
     private static final String ONE_MSG = String.format(MessageQueueProxyService.MESSAGES_CONSUMED, 1);
+    private static final String KAFKA_MESSAGE_CONTENT_TYPE = "application/vnd.kafka.v2+json";
     
     private MessageQueueProxyService messageQueueProxyService;
 
@@ -76,13 +77,42 @@ public class MessageQueueProxyServiceImplTest {
 
         assertThat(actualConsumerInstanceUri, is(equalTo(expectedUri)));
 
-        verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
+        verify(mockedBuilder).header(eq("Content-Type"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
         verify(mockedBuilder).header(eq("Host"), eq("kafka"));
         verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"false\"}");
         verify(mockedResponse, times(1)).close();
         
         assertThat(messageQueueProxyService.getStatus(), equalTo(NO_MSG));
     }
+
+    @Test
+    public void testBuildURL() throws Exception {
+
+        final URI responseUri = UriBuilder.fromUri("http://localhost:8080/consumers/binaryIngester/instances/rest-consumer-1-1").build();
+        final URI expectedUri = UriBuilder.fromUri("http://localhost:8082/consumers/binaryIngester/instances/rest-consumer-1-1").build();
+
+        final WebResource mockedWebResource = mock(WebResource.class);
+        when(client.resource(UriBuilder.fromUri("http://localhost:8082/consumers/binaryIngester").build())).thenReturn(mockedWebResource);
+        final WebResource.Builder mockedBuilder = mock(WebResource.Builder.class);
+        when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
+
+        final ClientResponse mockedResponse = mock(ClientResponse.class);
+        when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"false\"}")).thenReturn(mockedResponse);
+        when(mockedResponse.getStatus()).thenReturn(200);
+        when(mockedResponse.getEntity(ConsumerInstanceResponse.class)).thenReturn(new ConsumerInstanceResponse(responseUri));
+
+        URI actualConsumerInstanceUri = messageQueueProxyService.createConsumerInstance();
+
+        assertThat(actualConsumerInstanceUri, is(equalTo(expectedUri)));
+
+        verify(mockedBuilder).header(eq("Content-Type"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
+        verify(mockedBuilder).header(eq("Host"), eq("kafka"));
+        verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"false\"}");
+        verify(mockedResponse, times(1)).close();
+
+        assertThat(messageQueueProxyService.getStatus(), equalTo(NO_MSG));
+    }
+
 
     @Test
     public void testCreateConsumerInstanceWithAutocommit() throws Exception {
@@ -111,7 +141,7 @@ public class MessageQueueProxyServiceImplTest {
 
         assertThat(actualConsumerInstanceUri, is(equalTo(expectedUri)));
 
-        verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
+        verify(mockedBuilder).header(eq("Content-Type"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
         verify(mockedBuilder).header(eq("Host"), eq("kafka"));
         verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"true\"}");
         verify(mockedResponse, times(1)).close();
@@ -136,7 +166,7 @@ public class MessageQueueProxyServiceImplTest {
         try {
           messageQueueProxyService.createConsumerInstance();
         } finally {
-          verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
+          verify(mockedBuilder).header(eq("Content-Type"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
           verify(mockedBuilder).header(eq("Host"), eq("kafka"));
           verify(mockedResponse, times(1)).close();
           
@@ -159,7 +189,7 @@ public class MessageQueueProxyServiceImplTest {
         try {
           messageQueueProxyService.createConsumerInstance();
         } finally {
-          verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
+          verify(mockedBuilder).header(eq("Content-Type"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
           verify(mockedBuilder).header(eq("Host"), eq("kafka"));
           
           assertThat(messageQueueProxyService.getStatus(), equalTo(errorMessage));
@@ -276,7 +306,7 @@ public class MessageQueueProxyServiceImplTest {
 
         assertThat(actualMessageRecords.get(0).getValue(), is(equalTo("myrecord".getBytes())));
         verify(mockedBuilder).header(eq("Host"), eq("kafka"));
-        verify(mockedBuilder).header(eq("Accept"), eq("application/vnd.kafka.v2+json"));
+        verify(mockedBuilder).header(eq("Accept"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
         verify(mockedResponse, times(1)).close();
         
         assertThat(messageQueueProxyService.getStatus(), equalTo(ONE_MSG));
@@ -301,7 +331,7 @@ public class MessageQueueProxyServiceImplTest {
         assertThat(actualMessageRecords.get(0).getValue(), is(equalTo("myrecord".getBytes())));
         verify(client).resource(UriBuilder.fromUri(expectedOverridenUri).path("records").build());
         verify(mockedBuilder).header(eq("Host"), eq("kafka"));
-        verify(mockedBuilder).header(eq("Accept"), eq("application/vnd.kafka.v2+json"));
+        verify(mockedBuilder).header(eq("Accept"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
         verify(mockedResponse, times(1)).close();
         
         assertThat(messageQueueProxyService.getStatus(), equalTo(ONE_MSG));
@@ -326,7 +356,7 @@ public class MessageQueueProxyServiceImplTest {
           messageQueueProxyService.consumeMessages(consumerUri);
         } finally {
           verify(mockedBuilder).header(eq("Host"), eq("kafka"));
-          verify(mockedBuilder).header(eq("Accept"), eq("application/vnd.kafka.v2+json"));
+          verify(mockedBuilder).header(eq("Accept"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
           verify(mockedResponse, times(1)).close();
           
           assertThat(messageQueueProxyService.getStatus(), equalTo(errorMessage));
@@ -350,7 +380,7 @@ public class MessageQueueProxyServiceImplTest {
           messageQueueProxyService.consumeMessages(consumerUri);
         } finally {
           verify(mockedBuilder).header(eq("Host"), eq("kafka"));
-          verify(mockedBuilder).header(eq("Accept"), eq("application/vnd.kafka.v2+json"));
+          verify(mockedBuilder).header(eq("Accept"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
           
           assertThat(messageQueueProxyService.getStatus(), equalTo(errorMessage));
         }

--- a/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplTest.java
+++ b/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplTest.java
@@ -86,35 +86,6 @@ public class MessageQueueProxyServiceImplTest {
     }
 
     @Test
-    public void testBuildURL() throws Exception {
-
-        final URI responseUri = UriBuilder.fromUri("http://localhost:8080/consumers/binaryIngester/instances/rest-consumer-1-1").build();
-        final URI expectedUri = UriBuilder.fromUri("http://localhost:8082/consumers/binaryIngester/instances/rest-consumer-1-1").build();
-
-        final WebResource mockedWebResource = mock(WebResource.class);
-        when(client.resource(UriBuilder.fromUri("http://localhost:8082/consumers/binaryIngester").build())).thenReturn(mockedWebResource);
-        final WebResource.Builder mockedBuilder = mock(WebResource.Builder.class);
-        when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
-
-        final ClientResponse mockedResponse = mock(ClientResponse.class);
-        when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"false\"}")).thenReturn(mockedResponse);
-        when(mockedResponse.getStatus()).thenReturn(200);
-        when(mockedResponse.getEntity(ConsumerInstanceResponse.class)).thenReturn(new ConsumerInstanceResponse(responseUri));
-
-        URI actualConsumerInstanceUri = messageQueueProxyService.createConsumerInstance();
-
-        assertThat(actualConsumerInstanceUri, is(equalTo(expectedUri)));
-
-        verify(mockedBuilder).header(eq("Content-Type"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
-        verify(mockedBuilder).header(eq("Host"), eq("kafka"));
-        verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"false\"}");
-        verify(mockedResponse, times(1)).close();
-
-        assertThat(messageQueueProxyService.getStatus(), equalTo(NO_MSG));
-    }
-
-
-    @Test
     public void testCreateConsumerInstanceWithAutocommit() throws Exception {
         MessageQueueProxyService messageQueueProxyService = new MessageQueueProxyServiceImpl(
                 new MessageQueueConsumerConfiguration(

--- a/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplTest.java
+++ b/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.ft.message.consumer.proxy;
 
 import com.ft.message.consumer.config.MessageQueueConsumerConfiguration;
-import com.ft.message.consumer.proxy.model.CreateConsumerInstanceResponse;
+import com.ft.message.consumer.proxy.model.ConsumerInstanceResponse;
 import com.ft.message.consumer.proxy.model.MessageRecord;
 import com.google.common.collect.ImmutableList;
 import com.sun.jersey.api.client.Client;
@@ -71,7 +71,7 @@ public class MessageQueueProxyServiceImplTest {
         final ClientResponse mockedResponse = mock(ClientResponse.class);
         when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"false\"}")).thenReturn(mockedResponse);
         when(mockedResponse.getStatus()).thenReturn(200);
-        when(mockedResponse.getEntity(CreateConsumerInstanceResponse.class)).thenReturn(new CreateConsumerInstanceResponse(expectedUri));
+        when(mockedResponse.getEntity(ConsumerInstanceResponse.class)).thenReturn(new ConsumerInstanceResponse(expectedUri));
 
         URI actualConsumerInstanceUri = messageQueueProxyService.createConsumerInstance();
 
@@ -135,7 +135,7 @@ public class MessageQueueProxyServiceImplTest {
         final ClientResponse mockedResponse = mock(ClientResponse.class);
         when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"true\"}")).thenReturn(mockedResponse);
         when(mockedResponse.getStatus()).thenReturn(200);
-        when(mockedResponse.getEntity(CreateConsumerInstanceResponse.class)).thenReturn(new CreateConsumerInstanceResponse(expectedUri));
+        when(mockedResponse.getEntity(ConsumerInstanceResponse.class)).thenReturn(new ConsumerInstanceResponse(expectedUri));
 
         URI actualConsumerInstanceUri = messageQueueProxyService.createConsumerInstance();
 

--- a/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplWithEmptyQueueTest.java
+++ b/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplWithEmptyQueueTest.java
@@ -69,7 +69,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
 
         assertThat(actualConsumerInstanceUri, is(equalTo(expectedUri)));
 
-        verify(mockedBuilder).header(eq("Content-Type"), eq("application/json"));
+        verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
         verify(mockedBuilder, never()).header(eq("Host"), eq("kafka"));
         verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"false\"}");
         verify(mockedResponse, times(1)).close();
@@ -92,7 +92,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
         URI actualConsumerInstanceUri = messageQueueProxyService.createConsumerInstance();
 
         assertThat(actualConsumerInstanceUri, nullValue());
-        verify(mockedBuilder).header(eq("Content-Type"), eq("application/json"));
+        verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
         verify(mockedBuilder, never()).header(eq("Host"), eq("kafka"));
         verify(mockedResponse, times(1)).close();
     }
@@ -142,7 +142,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
         final URI consumerUri = UriBuilder.fromUri("http://localhost:8082/consumers/binaryIngester/instances/rest-consumer-1-1").build();
 
         final WebResource mockedWebResource = mock(WebResource.class);
-        when(client.resource(UriBuilder.fromUri(consumerUri).path("topics").path("CmsPublicationEvent").build())).thenReturn(mockedWebResource);
+        when(client.resource(UriBuilder.fromUri(consumerUri).path("records").build())).thenReturn(mockedWebResource);
         final WebResource.Builder mockedBuilder = mock(WebResource.Builder.class);
         when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
         final ClientResponse mockedResponse = mock(ClientResponse.class);
@@ -154,7 +154,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
 
         assertThat(actualMessageRecords.get(0).getValue(), is(equalTo("myrecord".getBytes())));
         verify(mockedBuilder, never()).header(eq("Host"), eq("kafka"));
-        verify(mockedBuilder).header(eq("Accept"), eq("application/json"));
+        verify(mockedBuilder).header(eq("Accept"), eq("application/vnd.kafka.v2+json"));
         verify(mockedResponse, times(1)).close();
     }
 
@@ -165,7 +165,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
         expectedException.expectMessage("Unable to consume messages. Proxy returned 500");
 
         final WebResource mockedWebResource = mock(WebResource.class);
-        when(client.resource(UriBuilder.fromUri(consumerUri).path("topics").path("CmsPublicationEvent").build())).thenReturn(mockedWebResource);
+        when(client.resource(UriBuilder.fromUri(consumerUri).path("records").build())).thenReturn(mockedWebResource);
         final WebResource.Builder mockedBuilder = mock(WebResource.Builder.class);
         when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
         final ClientResponse mockedResponse = mock(ClientResponse.class);
@@ -174,7 +174,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
 
         messageQueueProxyService.consumeMessages(consumerUri);
         verify(mockedBuilder, never()).header(eq("Host"), eq("kafka"));
-        verify(mockedBuilder).header(eq("Accept"), eq("application/json"));
+        verify(mockedBuilder).header(eq("Accept"), eq("application/vnd.kafka.v2+json"));
         verify(mockedResponse, times(1)).close();
     }
 

--- a/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplWithEmptyQueueTest.java
+++ b/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplWithEmptyQueueTest.java
@@ -1,7 +1,7 @@
 package com.ft.message.consumer.proxy;
 
 import com.ft.message.consumer.config.MessageQueueConsumerConfiguration;
-import com.ft.message.consumer.proxy.model.CreateConsumerInstanceResponse;
+import com.ft.message.consumer.proxy.model.ConsumerInstanceResponse;
 import com.ft.message.consumer.proxy.model.MessageRecord;
 import com.google.common.collect.ImmutableList;
 import com.sun.jersey.api.client.Client;
@@ -64,7 +64,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
         final ClientResponse mockedResponse = mock(ClientResponse.class);
         when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"false\"}")).thenReturn(mockedResponse);
         when(mockedResponse.getStatus()).thenReturn(200);
-        when(mockedResponse.getEntity(CreateConsumerInstanceResponse.class)).thenReturn(new CreateConsumerInstanceResponse(expectedUri));
+        when(mockedResponse.getEntity(ConsumerInstanceResponse.class)).thenReturn(new ConsumerInstanceResponse(expectedUri));
 
         URI actualConsumerInstanceUri = messageQueueProxyService.createConsumerInstance();
 

--- a/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplWithEmptyQueueTest.java
+++ b/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplWithEmptyQueueTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.*;
 public class MessageQueueProxyServiceImplWithEmptyQueueTest {
 
     private MessageQueueProxyService messageQueueProxyService;
+    private static final String KAFKA_MESSAGE_CONTENT_TYPE = "application/vnd.kafka.v2+json";
 
     @Mock
     private Client client;
@@ -69,7 +70,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
 
         assertThat(actualConsumerInstanceUri, is(equalTo(expectedUri)));
 
-        verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
+        verify(mockedBuilder).header(eq("Content-Type"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
         verify(mockedBuilder, never()).header(eq("Host"), eq("kafka"));
         verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"false\"}");
         verify(mockedResponse, times(1)).close();
@@ -92,7 +93,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
         URI actualConsumerInstanceUri = messageQueueProxyService.createConsumerInstance();
 
         assertThat(actualConsumerInstanceUri, nullValue());
-        verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
+        verify(mockedBuilder).header(eq("Content-Type"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
         verify(mockedBuilder, never()).header(eq("Host"), eq("kafka"));
         verify(mockedResponse, times(1)).close();
     }
@@ -154,7 +155,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
 
         assertThat(actualMessageRecords.get(0).getValue(), is(equalTo("myrecord".getBytes())));
         verify(mockedBuilder, never()).header(eq("Host"), eq("kafka"));
-        verify(mockedBuilder).header(eq("Accept"), eq("application/vnd.kafka.v2+json"));
+        verify(mockedBuilder).header(eq("Accept"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
         verify(mockedResponse, times(1)).close();
     }
 
@@ -174,7 +175,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
 
         messageQueueProxyService.consumeMessages(consumerUri);
         verify(mockedBuilder, never()).header(eq("Host"), eq("kafka"));
-        verify(mockedBuilder).header(eq("Accept"), eq("application/vnd.kafka.v2+json"));
+        verify(mockedBuilder).header(eq("Accept"), eq(KAFKA_MESSAGE_CONTENT_TYPE));
         verify(mockedResponse, times(1)).close();
     }
 

--- a/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplWithEmptyQueueTest.java
+++ b/src/test/java/com/ft/message/consumer/proxy/MessageQueueProxyServiceImplWithEmptyQueueTest.java
@@ -46,7 +46,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
                         "binaryIngester",
                         "http://localhost:8082",
                         "",
-                        8000, 1, "smallest", false),
+                        8000, 1, "earliest", false),
                 client);
     }
 
@@ -61,7 +61,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
         when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
 
         final ClientResponse mockedResponse = mock(ClientResponse.class);
-        when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"false\"}")).thenReturn(mockedResponse);
+        when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"false\"}")).thenReturn(mockedResponse);
         when(mockedResponse.getStatus()).thenReturn(200);
         when(mockedResponse.getEntity(CreateConsumerInstanceResponse.class)).thenReturn(new CreateConsumerInstanceResponse(expectedUri));
 
@@ -71,7 +71,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
 
         verify(mockedBuilder).header(eq("Content-Type"), eq("application/vnd.kafka.v2+json"));
         verify(mockedBuilder, never()).header(eq("Host"), eq("kafka"));
-        verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"false\"}");
+        verify(mockedBuilder).post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"false\"}");
         verify(mockedResponse, times(1)).close();
     }
 
@@ -86,7 +86,7 @@ public class MessageQueueProxyServiceImplWithEmptyQueueTest {
         final WebResource.Builder mockedBuilder = mock(WebResource.Builder.class);
         when(mockedWebResource.getRequestBuilder()).thenReturn(mockedBuilder);
         final ClientResponse mockedResponse = mock(ClientResponse.class);
-        when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"smallest\", \"auto.commit.enable\": \"false\"}")).thenReturn(mockedResponse);
+        when(mockedBuilder.post(ClientResponse.class, "{\"auto.offset.reset\": \"earliest\", \"auto.commit.enable\": \"false\"}")).thenReturn(mockedResponse);
         when(mockedResponse.getStatus()).thenReturn(500);
 
         URI actualConsumerInstanceUri = messageQueueProxyService.createConsumerInstance();


### PR DESCRIPTION
UPPSF-970 Update the message-queue-consumer library to use the v2 of the REST proxy API

The implementation in 
src/main/java/com/ft/message/consumer/health/CanConnectToMessageQueueProxyHealthcheck.java
has to be evaluated if it is used and to be migrated also.
